### PR TITLE
Update deeplabcut_handler.py

### DIFF
--- a/skellyclicker/core/deeplabcut_handler/deeplabcut_handler.py
+++ b/skellyclicker/core/deeplabcut_handler/deeplabcut_handler.py
@@ -159,19 +159,21 @@ class DeeplabcutHandler(BaseModel):
         annotate_videos: bool = False,
     ) -> str:
         config = auxiliaryfunctions.read_config(self.project_config_path)
+        output_folder = (
+            Path(config["project_path"])
+            / f"model_outputs_iteration_{config['iteration']}"
+        )
+        output_folder.mkdir(parents=True, exist_ok=True)
 
         deeplabcut.analyze_videos(
             config=str(self.project_config_path),
             videos=video_paths,
             videotype=".mp4",
             save_as_csv=True,
+            destfolder = str(output_folder)
         )
 
-        output_folder = (
-            Path(config["project_path"])
-            / f"model_outputs_iteration_{config['iteration']}"
-        )
-        output_folder.mkdir(parents=True, exist_ok=True)
+
         if annotate_videos:
             print(
                 f"Annotating videos {video_paths}, saving to {output_folder}"


### PR DESCRIPTION
Just an example of how the `analyze_videos` function could be fixed - the `destfolder` parameter now saves the analyzed video data into the `model_outputs_iteration_[x]` folder, and the `create_labeled_video` function reads from that folder as well. 