### PR TITLE
Turn off threading on linux to allow reopening labelling window

### DIFF
--- a/skellyclicker/core/video_handler/video_viewer.py
+++ b/skellyclicker/core/video_handler/video_viewer.py
@@ -48,6 +48,9 @@ class VideoViewer(BaseModel):
         if sys.platform == "darwin":  # OpenCV GUI can only open in main thread on Mac
             self.video_thread = None
             self.run()
+        elif sys.platform == "linux":
+            self.video_thread = None
+            self.run()
         else:
             self.video_thread = threading.Thread(target=self.run)
             self.video_thread.daemon = True


### PR DESCRIPTION
Due to some under the hood threading logic in opencv, once one opencv window was opened in a thread, you couldn't open another window in a different thread. This means you couldn't label, save your work, train, and then relabel without closing the program between labelling sessions. This PR turns off threading for the opencv windows to allow retraining without closing the software. The only cost is the main UI is now blocked while the labeling window is open