### PR TITLE
View labelled data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -174,3 +174,4 @@ cython_debug/
 .pypirc
 skellyclicker/.DS_Store
 .DS_Store
+.vscode/settings.json

--- a/skellyclicker/core/deeplabcut_handler/deeplabcut_handler.py
+++ b/skellyclicker/core/deeplabcut_handler/deeplabcut_handler.py
@@ -196,7 +196,8 @@ class DeeplabcutHandler(BaseModel):
             save_as_csv=True,
             destfolder = str(output_folder),
             batch_size=8,  # 16 is too high for 5 mocap videos
-            multiprocess=False
+            multiprocess=True,
+            overwrite=True
         )
 
         if filter_videos:

--- a/skellyclicker/scripts/flip_pupil_labelled_data.py
+++ b/skellyclicker/scripts/flip_pupil_labelled_data.py
@@ -1,0 +1,77 @@
+import pandas as pd
+from pathlib import Path
+
+from skellyclicker.scripts.flip_video import FlipMethod, flip_video
+
+PUPIL_VIDEO_HEIGHT = 400
+PUPIL_VIDEO_WIDTH = 400
+
+def swap_columns(df: pd.DataFrame, column_1: str, column_2: str) -> pd.DataFrame:
+    df[column_1], df[column_2] = df[column_2].copy(), df[column_1].copy()
+    return df
+
+def flip_pupil_data_horizontal(df: pd.DataFrame) -> pd.DataFrame:
+    # swap p2 and p8 columns
+    df = swap_columns(df, "p2_x", "p8_x")
+    df = swap_columns(df, "p2_y", "p8_y")
+
+    # swap p3 and p7 columns
+    df = swap_columns(df, "p3_x", "p7_x")
+    df = swap_columns(df, "p3_y", "p7_y")
+
+    # flip p4 and p6 columns
+    df = swap_columns(df, "p4_x", "p6_x")
+    df = swap_columns(df, "p4_y", "p6_y")
+
+    return df
+
+def flip_pupil_data_vertical(df: pd.DataFrame) -> pd.DataFrame:
+    # swap p8 and p6 columns
+    df = swap_columns(df, "p6_x", "p8_x")
+    df = swap_columns(df, "p6_y", "p8_y")
+
+    # swap p1 and p5 columns
+    df = swap_columns(df, "p1_x", "p5_x")
+    df = swap_columns(df, "p1_y", "p5_y")
+
+    # swap p2 and p4 columns
+    df = swap_columns(df, "p2_x", "p4_x")
+    df = swap_columns(df, "p2_y", "p4_y")
+
+    return df
+
+def flip_pupil_data_in_image_vertical(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    y_cols = [col for col in df.columns if '_y' in col]
+    for col in y_cols:
+        print(f"Vertical flipping data in {col}")
+        df[col] = PUPIL_VIDEO_HEIGHT - df[col]
+    return df
+
+def flip_pupil_data_in_image_horizontal(df: pd.DataFrame) -> pd.DataFrame:
+    df = df.copy()
+    x_cols = [col for col in df.columns if '_x' in col]
+    for col in x_cols:
+        print(f"Horizontal flipping data in {col}")
+        df[col] = PUPIL_VIDEO_WIDTH - df[col]
+    return df
+
+
+if __name__=='__main__':
+    df_path = Path("/home/scholl-lab/ferret_recordings/session_2025-10-11_ferret_420_E02/base_data/skellyclicker_data/2025-12-07_12-02-14_skellyclicker_output.csv")
+    video_path = Path("/home/scholl-lab/ferret_recordings/session_2025-10-11_ferret_420_E02/base_data/pupil_output/eye0.mp4")
+
+    df = pd.read_csv(df_path)
+
+    df = flip_pupil_data_horizontal(df)
+    df = flip_pupil_data_vertical(df)
+    df = flip_pupil_data_in_image_horizontal(df)
+    df = flip_pupil_data_in_image_vertical(df)
+
+    new_df_name = f"{df_path.stem}_corrected_pupil_orientation"
+    df.to_csv(df_path.with_stem(new_df_name), index=False)
+    print(f"Saved csv to {new_df_name}")
+
+    print("Flipping video")
+    flip_video(video=video_path, flip_method=FlipMethod.BOTH)
+

--- a/skellyclicker/scripts/process_recording.py
+++ b/skellyclicker/scripts/process_recording.py
@@ -19,6 +19,16 @@ def copy_files(files: list[Path], destination: Path):
     for file_path in files:
         shutil.copy2(src = file_path, dst=destination)
 
+def clean_dlc_output_folder(dlc_output_folder: Path):
+    if not dlc_output_folder.exists() or not dlc_output_folder.is_dir():
+        return
+    print("Existing dlc data found, removing it to ensure latest model is used")
+    patterns = ["*snapshot*.csv", "*snapshot*.h5", "*snapshot*.pickle"]
+    for pattern in patterns:
+        for file in dlc_output_folder.glob(pattern):
+            print(f"Removing existinng file {file}")
+            file.unlink()
+
 def process_recording(video_folder: Path, deeplabcut_folder: Path | str, output_folder: Path | None = None, suffix: str = ""):
     if output_folder is None:
         output_folder = video_folder.parent
@@ -28,6 +38,7 @@ def process_recording(video_folder: Path, deeplabcut_folder: Path | str, output_
     dlc_output_folder.mkdir(exist_ok=True, parents=True)
     annotated_videos_folder.mkdir(exist_ok=True, parents=True)
     analyze_videos_output = dlc_output_folder / f"{deeplabcut_folder.stem}{suffix}"
+    clean_dlc_output_folder(analyze_videos_output)
     deeplabcut_config = deeplabcut_folder / "config.yaml"
     handler = DeeplabcutHandler.load_deeplabcut_project(project_config_path=str(deeplabcut_config))
     video_paths = [str(path) for path in video_folder.glob("*.mp4")]
@@ -71,7 +82,7 @@ def run_all_models(recording_path: Path, include_eye: bool, flip_eye_0: bool = F
 
 if __name__=="__main__":
     # use /full_recording or /clips/{clip_name}
-    recording_path = Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s")
+    recording_path = Path("/home/scholl-lab/ferret_recordings/session_2025-07-09_ferret_753_EyeCameras_P41_E13/full_recording")
     include_eye = True
 
     if "757" in str(recording_path):

--- a/skellyclicker/scripts/view_labelled_data.py
+++ b/skellyclicker/scripts/view_labelled_data.py
@@ -1,33 +1,123 @@
 from pathlib import Path
+import numpy as np
 import pandas as pd
 import cv2
 
 def load_deeplabcut_labels(csv_path: Path) -> pd.DataFrame:
     return pd.read_csv(csv_path, header=[1,2], skiprows=0)
 
+def hsv_to_rgb(hsv: np.ndarray) -> np.ndarray:
+    """Convert HSV color to RGB."""
+    h, s, v = hsv
+    hi = int(h * 6.) % 6
+    f = h * 6. - int(h * 6.)
+    p = v * (1. - s)
+    q = v * (1. - f * s)
+    t = v * (1. - (1. - f) * s)
+
+    if hi == 0:
+        return np.array([v, t, p])
+    elif hi == 1:
+        return np.array([q, v, p])
+    elif hi == 2:
+        return np.array([p, v, t])
+    elif hi == 3:
+        return np.array([p, q, v])
+    elif hi == 4:
+        return np.array([t, p, v])
+    else:
+        return np.array([v, p, q])
+
+def get_colors(keys: list[str]) -> dict[str, tuple[int, ...]]:
+    np.random.seed(42)
+
+    hues = np.linspace(0, 1, len(keys), endpoint=False)
+
+    # Convert HSV to RGB
+    rgb_values = []
+    for hue in hues:
+        hsv = np.array([hue, 1, 0.95])
+        rgb = hsv_to_rgb(hsv)
+        rgb_values.append(tuple(map(int, rgb * 255)))
+
+    colors = {}
+    for tracked_point, color in zip(keys, rgb_values):
+        colors[tracked_point] = color
+
+    return colors
+
 def view_labelled_data(csv_path: Path):
-    project_folder = csv_path.parent.parent
+    project_folder = csv_path.parent.parent.parent
     df = load_deeplabcut_labels(csv_path)
     print(df.head(5))
     
     bodyparts = df.columns.get_level_values(0).unique()
-    for bodypart in bodyparts:
-        print(f"Bodypart: {bodypart}")
+
+
+    colors = get_colors(bodyparts[1:])
+
+    # for bodypart in bodyparts[1:]:
+    #     print(f"Bodypart: {bodypart} Color: {colors[bodypart]}")
 
     for index, row in df.iterrows():
-        path_stem = ""
+        path_stem = row["bodyparts", "coords"]
         image_path = project_folder / path_stem
         image = cv2.imread(str(image_path))
 
-        for bodypart in bodyparts:
-            x = row[bodypart]["x"]
-            y = row[bodypart]["y"]
-            cv2.circle(image, (int(x), int(y)), 5, (0, 0, 255), -1)
+        cv2.putText(image, path_stem.split("/")[-1], (2, 40), cv2.FONT_HERSHEY_SIMPLEX, 2, (0,0,255), 1)
 
-        cv2.imshow(f"{path_stem}", image)
-        cv2.waitKey(0)
+        for bodypart in bodyparts[1:]:
+            x = row[bodypart, "x"]
+            y = row[bodypart, "y"]
+            try:
+                x = int(x)
+                y = int(y)
+            except ValueError as e:
+                print(f"got exception {e}")
+                print(f"Check data for image {path_stem} for null values")
+                continue
+
+            marker_color = colors.get(bodypart, (255, 0, 255))
+            cv2.drawMarker(
+                image,
+                position=(x, y),
+                color=(1, 1, 1),
+                markerType=cv2.MARKER_DIAMOND,
+                markerSize=20,
+                thickness=2,
+            )
+            cv2.drawMarker(
+                image,
+                position=(x, y),
+                color=marker_color,
+                markerType=cv2.MARKER_DIAMOND,
+                markerSize=15,
+                thickness=1,
+            )
+            cv2.putText(
+                image,
+                bodypart,
+                (x+15, y-15),
+                cv2.FONT_HERSHEY_PLAIN,
+                1,
+                marker_color,
+                1
+            )
+
+        print(f"showing {path_stem}")
+        cv2.imshow("Labelled Data", image)
+        key = cv2.waitKey(0)
+        if key == ord('0'):
+            break
+        elif key == ord('q'):
+            continue
+
+    cv2.destroyAllWindows()
 
 
 if __name__ == "__main__":
-    csv_path = Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s/mocap_data/dlc_output/skellyclicker_machine_labels_iteration_1.csv")
+    data_folder_path = Path(
+        "/home/scholl-lab/deeplabcut_data/eye_model_v3/labeled-data/session_2025-10-11_ferret_420_E02_eye0"
+    )
+    csv_path = data_folder_path / "CollectedData_human.csv"
     view_labelled_data(csv_path)

--- a/skellyclicker/scripts/view_labelled_data.py
+++ b/skellyclicker/scripts/view_labelled_data.py
@@ -1,0 +1,33 @@
+from pathlib import Path
+import pandas as pd
+import cv2
+
+def load_deeplabcut_labels(csv_path: Path) -> pd.DataFrame:
+    return pd.read_csv(csv_path, header=[1,2], skiprows=0)
+
+def view_labelled_data(csv_path: Path):
+    project_folder = csv_path.parent.parent
+    df = load_deeplabcut_labels(csv_path)
+    print(df.head(5))
+    
+    bodyparts = df.columns.get_level_values(0).unique()
+    for bodypart in bodyparts:
+        print(f"Bodypart: {bodypart}")
+
+    for index, row in df.iterrows():
+        path_stem = ""
+        image_path = project_folder / path_stem
+        image = cv2.imread(str(image_path))
+
+        for bodypart in bodyparts:
+            x = row[bodypart]["x"]
+            y = row[bodypart]["y"]
+            cv2.circle(image, (int(x), int(y)), 5, (0, 0, 255), -1)
+
+        cv2.imshow(f"{path_stem}", image)
+        cv2.waitKey(0)
+
+
+if __name__ == "__main__":
+    csv_path = Path("/home/scholl-lab/ferret_recordings/session_2025-07-11_ferret_757_EyeCamera_P43_E15__1/clips/0m_37s-1m_37s/mocap_data/dlc_output/skellyclicker_machine_labels_iteration_1.csv")
+    view_labelled_data(csv_path)


### PR DESCRIPTION
Add a helper script for viewing labelled data. This allows you to check the exact data going into the model for training, and see if you had any slip ups during labelling.

This also adds some other improvements, like cleaning out the dlc_output folder at the start of inference and having a `try multiprocessing` approach for each model type