### PR TITLE
fix: pin setuptools<81 to restore pkg_resources.parse_version

### DIFF
--- a/skellyclicker_env.yaml
+++ b/skellyclicker_env.yaml
@@ -28,6 +28,7 @@ channels:
   - defaults
 dependencies:
   - python=3.11
+  - setuptools<81
   - pip
   - ipython
   - jupyter


### PR DESCRIPTION
setuptools 81 removed parse_version from the pkg_resources API, breaking environment creation for packages that still import it via `from pkg_resources import parse_version`.

Pin setuptools<81 in environment.yml so the symbol remains available until the affected dependency migrates to packaging.version.parse.